### PR TITLE
Add AllowSettingsClassesThatDoNotHaveConfigurationEntries option

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,17 @@ IF you genuinely don't want to assert that nobody is using silly/dangerous inlin
                              
 This approach is also useful for environments like Windows Azure, where 1) enumerating all configuration settings is not supported and 2) the hosting environment may randomly add unexpected settings to your application's configuration.
 
+You can also ignore the reverse of this, i.e. settings classes that don't have a corresponding configuration entry, by using the following:
+
+    ConfigurationConfigurator.RegisterConfigurationSettings()
+                             .FromAssemblies(/* TODO: Provide a list of assemblies to scan for configuration settings here  */)
+                             .RegisterWithContainer(configSetting => /* TODO: Register this instance with your container here */ )
+                             .AllowSettingsClassesThatDoNotHaveConfigurationEntries(true)
+                             .DoYourThing();
+
+This can be useful if you have a shared set of configuration settings, but some applications don't need to specify or resolve values for all of the settings. The configuration settings that don't exist in the `[web|app].config` file won't be registered with the container.
+
+
 ## Can I load settings directly without configuring my container first?
 
 You can do this but I'd give some serious thought to whether it's a good idea in your particular case.

--- a/src/ConfigInjector.UnitTests/WhenReadingTheValueForASettingThatDoesNotExist.cs
+++ b/src/ConfigInjector.UnitTests/WhenReadingTheValueForASettingThatDoesNotExist.cs
@@ -19,6 +19,7 @@ namespace ConfigInjector.UnitTests
             return new SettingsRegistrationService(new AssemblyScanningTypeProvider(assemblies),
                                                    setting => { },
                                                    true,
+                                                   false,
                                                    new SettingValueConverter(),
                                                    settingsReader,
                                                    SettingKeyConventions.BuiltInConventions.ToArray());

--- a/src/ConfigInjector.UnitTests/WhenThereAreSettingsThatExistInWebConfigButAreNotAccountedFor.cs
+++ b/src/ConfigInjector.UnitTests/WhenThereAreSettingsThatExistInWebConfigButAreNotAccountedFor.cs
@@ -19,6 +19,7 @@ namespace ConfigInjector.UnitTests
             return new SettingsRegistrationService(new AssemblyScanningTypeProvider(assemblies),
                                                    setting => { },
                                                    false,
+                                                   false,
                                                    new SettingValueConverter(),
                                                    settingsReader,
                                                    SettingKeyConventions.BuiltInConventions.ToArray());

--- a/src/ConfigInjector.UnitTests/WhenThereAreSettingsThatHaveAmbiguousMatchesInWebConfig.cs
+++ b/src/ConfigInjector.UnitTests/WhenThereAreSettingsThatHaveAmbiguousMatchesInWebConfig.cs
@@ -19,6 +19,7 @@ namespace ConfigInjector.UnitTests
             return new SettingsRegistrationService(new AssemblyScanningTypeProvider(assemblies), 
                                                    setting => { },
                                                    false,
+                                                   false,
                                                    new SettingValueConverter(),
                                                    settingsReader,
                                                    SettingKeyConventions.BuiltInConventions.ToArray());

--- a/src/ConfigInjector.sln
+++ b/src/ConfigInjector.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30723.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfigInjector", "ConfigInjector\ConfigInjector.csproj", "{9C2819AE-BA24-4A8B-9091-BDD3D53AC3E0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.WithAutofac", "Sample.WithAutofac\Sample.WithAutofac.csproj", "{8AFCB5B0-68CC-4F72-9D2D-BA511011C1FC}"
@@ -23,6 +25,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfigInjector.UnitTests", "ConfigInjector.UnitTests\ConfigInjector.UnitTests.csproj", "{3343E4BD-01F2-4A04-9B5D-B3A2F973A803}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.IntegrationTests", "Sample.IntegrationTests\Sample.IntegrationTests.csproj", "{F0927DDA-1CC4-47DA-AC84-6E2107B81D4B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration", "Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration\Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration.csproj", "{90D72CB9-C90E-43C3-AA87-8C1CC7BDCB8C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -62,16 +66,21 @@ Global
 		{F0927DDA-1CC4-47DA-AC84-6E2107B81D4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F0927DDA-1CC4-47DA-AC84-6E2107B81D4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F0927DDA-1CC4-47DA-AC84-6E2107B81D4B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{90D72CB9-C90E-43C3-AA87-8C1CC7BDCB8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{90D72CB9-C90E-43C3-AA87-8C1CC7BDCB8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{90D72CB9-C90E-43C3-AA87-8C1CC7BDCB8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{90D72CB9-C90E-43C3-AA87-8C1CC7BDCB8C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{8AFCB5B0-68CC-4F72-9D2D-BA511011C1FC} = {47A972A5-489B-4F5F-BEAC-8C5F2202E313}
 		{51CD02CA-71E4-48E4-A2DD-1D8F2AA71DC6} = {47A972A5-489B-4F5F-BEAC-8C5F2202E313}
 		{79199283-6541-4370-BA9B-2BA1ADF818EF} = {47A972A5-489B-4F5F-BEAC-8C5F2202E313}
 		{967394B0-1AF3-48AF-9624-AE45E8E0D3DC} = {47A972A5-489B-4F5F-BEAC-8C5F2202E313}
 		{0285D32A-2222-4C48-B1D2-8070ED518450} = {47A972A5-489B-4F5F-BEAC-8C5F2202E313}
-		{8AFCB5B0-68CC-4F72-9D2D-BA511011C1FC} = {47A972A5-489B-4F5F-BEAC-8C5F2202E313}
 		{F0927DDA-1CC4-47DA-AC84-6E2107B81D4B} = {47A972A5-489B-4F5F-BEAC-8C5F2202E313}
+		{90D72CB9-C90E-43C3-AA87-8C1CC7BDCB8C} = {47A972A5-489B-4F5F-BEAC-8C5F2202E313}
 	EndGlobalSection
 EndGlobal

--- a/src/ConfigInjector/Configuration/DoYourThingConfigurationConfigurator.cs
+++ b/src/ConfigInjector/Configuration/DoYourThingConfigurationConfigurator.cs
@@ -14,6 +14,7 @@ namespace ConfigInjector.Configuration
         private readonly Action<IConfigurationSetting> _registerAsSingleton;
 
         private bool _allowConfigurationEntriesThatDoNotHaveSettingsClasses;
+        private bool _allowSettingsClassesThatDoNotHaveConfigurationEntries;
         private readonly List<IValueParser> _customValueParsers = new List<IValueParser>();
         private ISettingsReader _settingsReader;
 
@@ -35,6 +36,17 @@ namespace ConfigInjector.Configuration
         public DoYourThingConfigurationConfigurator AllowConfigurationEntriesThatDoNotHaveSettingsClasses(bool allow)
         {
             _allowConfigurationEntriesThatDoNotHaveSettingsClasses = allow;
+            return this;
+        }
+
+        /// <summary>
+        /// If set to false (default), ConfigInjector will blow up when there are setting types
+        /// that do not have corresponding settings in the [web|app].config file. Setting types
+        /// without a corresponding setting will not be registered with the container.
+        /// </summary>
+        public DoYourThingConfigurationConfigurator AllowSettingsClassesThatDoNotHaveConfigurationEntries(bool allow)
+        {
+            _allowSettingsClassesThatDoNotHaveConfigurationEntries = allow;
             return this;
         }
 
@@ -78,6 +90,7 @@ namespace ConfigInjector.Configuration
             var appConfigConfigurationProvider = new SettingsRegistrationService(_typeProvider,
                                                                                  _registerAsSingleton,
                                                                                  _allowConfigurationEntriesThatDoNotHaveSettingsClasses,
+                                                                                 _allowSettingsClassesThatDoNotHaveConfigurationEntries,
                                                                                  settingValueConverter,
                                                                                  settingsReader,
                                                                                  _settingKeyConventions.ToArray());

--- a/src/Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration/App.config
+++ b/src/Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="HowGreatAreTheSmiths" value="Better than Aerosmith"/>
+  </appSettings>
+</configuration>

--- a/src/Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration/ConfigurationSettings/HowGreatAreTheSmithsSetting.cs
+++ b/src/Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration/ConfigurationSettings/HowGreatAreTheSmithsSetting.cs
@@ -1,0 +1,8 @@
+﻿using ConfigInjector;
+
+namespace Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration.ConfigurationSettings
+{
+    public class HowGreatAreTheSmithsSetting : ConfigurationSetting<string>
+    {
+    }
+}

--- a/src/Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration/ConfigurationSettings/SomethingThatIsNotInAppConfigSetting.cs
+++ b/src/Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration/ConfigurationSettings/SomethingThatIsNotInAppConfigSetting.cs
@@ -1,0 +1,8 @@
+﻿using ConfigInjector;
+
+namespace Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration.ConfigurationSettings
+{
+    public class SomethingThatIsNotInAppConfigSetting : ConfigurationSetting<string>
+    {
+    }
+}

--- a/src/Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration/Properties/AssemblyInfo.cs
+++ b/src/Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("fc9347be-e649-4995-91f2-bc3c377ebba3")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration/Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration.csproj
+++ b/src/Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration/Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration.csproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{90D72CB9-C90E-43C3-AA87-8C1CC7BDCB8C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration</RootNamespace>
+    <AssemblyName>Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Shouldly">
+      <HintPath>..\packages\Shouldly.1.1.1.1\lib\35\Shouldly.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="ConfigurationSettings\HowGreatAreTheSmithsSetting.cs" />
+    <Compile Include="ConfigurationSettings\SomethingThatIsNotInAppConfigSetting.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WhenConfiguratingTheConfigurator.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ConfigInjector\ConfigInjector.csproj">
+      <Project>{9c2819ae-ba24-4a8b-9091-bdd3d53ac3e0}</Project>
+      <Name>ConfigInjector</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration/WhenConfiguratingTheConfigurator.cs
+++ b/src/Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration/WhenConfiguratingTheConfigurator.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using ConfigInjector;
+using ConfigInjector.Configuration;
+using ConfigInjector.Exceptions;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration
+{
+    public class WhenConfiguratingTheConfigurator
+    {
+        [TestFixture]
+        public class WithDefaultConfiguration
+        {
+            [Test]
+            public void TheConfiguratorShouldBlowUp()
+            {
+                // Because there is a configuration setting that isn't
+                // in App.Settings (SomethingThatIsNotInAppConfigSetting)
+
+                Should.Throw<MissingSettingException>(() =>
+                {
+                    var configurationSettings = new List<IConfigurationSetting>();
+                    
+                    ConfigurationConfigurator.RegisterConfigurationSettings()
+                                             .FromAssemblies(Assembly.GetExecutingAssembly())
+                                             .RegisterWithContainer(configurationSettings.Add)
+                                             .DoYourThing();
+                });
+            }
+        }
+
+        [TestFixture]
+        public class AllowingConfigurationEntriesThatDoNotHaveSettingsClasses
+        {
+            [Test]
+            public void TheConfiguratorShouldNotBlowUp()
+            {
+                Should.NotThrow(() =>
+                {
+                    var configurationSettings = new List<IConfigurationSetting>();
+
+                    ConfigurationConfigurator.RegisterConfigurationSettings()
+                                             .FromAssemblies(Assembly.GetExecutingAssembly())
+                                             .RegisterWithContainer(configurationSettings.Add)
+                                             .AllowSettingsClassesThatDoNotHaveConfigurationEntries(true)
+                                             .DoYourThing();
+                });
+            }
+        }
+    }
+}

--- a/src/Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration/packages.config
+++ b/src/Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="Shouldly" version="1.1.1.1" targetFramework="net45" />
+</packages>

--- a/src/packages/repositories.config
+++ b/src/packages/repositories.config
@@ -3,6 +3,7 @@
   <repository path="..\ConfigInjector.UnitTests\packages.config" />
   <repository path="..\ConfigInjector\packages.config" />
   <repository path="..\Sample.IntegrationTests\packages.config" />
+  <repository path="..\Sample.IntegrationTestsWithSettingsThatDoNotHaveConfiguration\packages.config" />
   <repository path="..\Sample.UnitTests\packages.config" />
   <repository path="..\Sample.WithAutofac\packages.config" />
   <repository path="..\Sample.WithNinject\packages.config" />


### PR DESCRIPTION
This is the reverse scenario of allowing config entries without settings classes - allowing settings classes without corresponding configuration entries.

Useful if the config settings classes are shared across several projects, some of which don't want or need to specify all of the configuration settings. Such as a migration runner that only needs a couple of database connection strings, but you want shared config so it's easier to manage both locally and in CI (vis. Octopus configuration).

If the config setting isn't found in `web|app.config` it is skipped and not registered with the container, so it is up to the individual project to avoid depending on the skipped setting.
