### PR TITLE
Sensitive logging

### DIFF
--- a/src/ConfigInjector.UnitTests/ConfigInjector.UnitTests.csproj
+++ b/src/ConfigInjector.UnitTests/ConfigInjector.UnitTests.csproj
@@ -50,6 +50,8 @@
     <Compile Include="Stubs\StubTypeProvider.cs" />
     <Compile Include="Stubs\StubSettingsOverrider.cs" />
     <Compile Include="Stubs\StubSettingsReader.cs" />
+    <Compile Include="Tests\InstrumentationTests\WhenLoggingAnOverridenSetting.cs" />
+    <Compile Include="Tests\InstrumentationTests\WhenLoggingASetting.cs" />
     <Compile Include="Tests\ObjectSettingsReaderTests\WhenReadingNestedSettingsFromAnObjectSettingsReader.cs" />
     <Compile Include="Tests\ObjectSettingsReaderTests\WhenReadingSettingsUsingAnObjectSettingsReader.cs" />
     <Compile Include="Tests\OverriddenSettingsTests\WhenOverridingASettingViaAnEnvironmentVariable.cs" />

--- a/src/ConfigInjector.UnitTests/Tests/InstrumentationTests/WhenLoggingASetting.cs
+++ b/src/ConfigInjector.UnitTests/Tests/InstrumentationTests/WhenLoggingASetting.cs
@@ -1,0 +1,109 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using ConfigInjector.Infrastructure;
+using ConfigInjector.Infrastructure.Logging;
+using ConfigInjector.Infrastructure.SettingsConventions;
+using ConfigInjector.Infrastructure.SettingsOverriders;
+using ConfigInjector.UnitTests.Stubs;
+using NUnit.Framework;
+
+namespace ConfigInjector.UnitTests.Tests.InstrumentationTests
+{
+    [TestFixture]
+    internal class WhenLoggingASetting : TestFor<SettingsRegistrationService>
+    {
+        private SomeRecordingLogger _logger;
+
+        [SetUp]
+        public void TestSetup()
+        {
+            _logger.LogEntries.Clear();
+        }
+
+        protected override SettingsRegistrationService Given()
+        {
+            var typeProvider = new StubTypeProvider(typeof (SensitiveAndSanitized));
+
+            var settingsReader = new StubSettingsReader(new Dictionary<string, string>
+                                                        {
+                                                            {typeof(SensitiveAndSanitized).Name, SensitiveAndSanitized.OriginalValueRepresentation},
+                                                            {typeof(SensitiveAndUnsanitized).Name, SensitiveAndUnsanitized.OriginalValueRepresentation}
+                                                        });
+            _logger = new SomeRecordingLogger();
+
+            return new SettingsRegistrationService(_logger,
+                                                   typeProvider,
+                                                   SettingKeyConventions.BuiltInConventions.ToArray(),
+                                                   settingsReader,
+                                                   new NoOpSettingsOverrider(),
+                                                   new SettingValueConverter(),
+                                                   true,
+                                                   setting => { }
+                                                   );
+        }
+
+        protected override void When()
+        {
+        }
+
+        private class SomeRecordingLogger : IConfigInjectorLogger
+        {
+            public List<string> LogEntries { get; }
+
+            public SomeRecordingLogger()
+            {
+                LogEntries = new List<string>();
+            }
+
+            public void Log(string template, params object[] args)
+            {
+                LogEntries.Add(string.Format(template, args));
+            }
+        }
+
+        private class SensitiveAndUnsanitized : ConfigurationSetting<string>
+        {
+            public const string OriginalValueRepresentation = "SomewhatSensitive";
+
+            public override bool IsSensitive { get { return true; } }
+        }
+
+        private class SensitiveAndSanitized : ConfigurationSetting<string>
+        {
+            public const string OriginalValueRepresentation = "ReallySensitive";
+            public const string SanitizedValueRepresentation = "#####";
+
+            public override bool IsSensitive { get { return true; } }
+            public override string SanitizedValue { get { return SanitizedValueRepresentation; } }
+        }
+
+        [Test]
+        public void ASensitiveSettingWithoutASanitizedValueOverrideWillNotMaskTheLogOutput()
+        {
+            Subject.GetConfigSettingFor(typeof(SensitiveAndUnsanitized));
+
+            CollectionAssert.IsNotEmpty(_logger.LogEntries);
+
+            var logEntry = _logger.LogEntries.First();
+
+            Assert.IsTrue(logEntry.Contains(typeof(SensitiveAndUnsanitized).Name));
+
+            Assert.IsTrue(logEntry.Contains(SensitiveAndUnsanitized.OriginalValueRepresentation));
+        }
+
+        [Test]
+        public void ASensitiveSettingWithASanitizedValueWillMaskTheLogOutput()
+        {
+            Subject.GetConfigSettingFor(typeof (SensitiveAndSanitized));
+
+            CollectionAssert.IsNotEmpty(_logger.LogEntries);
+
+            var logEntry = _logger.LogEntries.First();
+
+            Assert.IsTrue(logEntry.Contains(typeof(SensitiveAndSanitized).Name));
+
+            Assert.IsFalse(logEntry.Contains(SensitiveAndSanitized.OriginalValueRepresentation));
+            Assert.IsTrue(logEntry.Contains(SensitiveAndSanitized.SanitizedValueRepresentation));
+        }
+    }
+}

--- a/src/ConfigInjector.UnitTests/Tests/InstrumentationTests/WhenLoggingAnOverridenSetting.cs
+++ b/src/ConfigInjector.UnitTests/Tests/InstrumentationTests/WhenLoggingAnOverridenSetting.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ConfigInjector.Infrastructure;
+using ConfigInjector.Infrastructure.Logging;
+using ConfigInjector.Infrastructure.SettingsConventions;
+using ConfigInjector.Infrastructure.SettingsOverriders;
+using ConfigInjector.UnitTests.Stubs;
+using NUnit.Framework;
+
+namespace ConfigInjector.UnitTests.Tests.InstrumentationTests
+{
+    [TestFixture]
+    internal class WhenLoggingAnOverridenSetting : TestFor<SettingsRegistrationService>
+    {
+        private SomeRecordingLogger _logger;
+
+        [SetUp]
+        public void TestSetup()
+        {
+            _logger.LogEntries.Clear();
+        }
+
+        protected override SettingsRegistrationService Given()
+        {
+            var typeProvider = new StubTypeProvider(typeof (SensitiveAndSanitized));
+
+            var settingsReader = new StubSettingsReader(new Dictionary<string, string>
+                                                        {
+                                                            {typeof(SensitiveAndSanitized).Name, SensitiveAndSanitized.OriginalValueRepresentation},
+                                                            {typeof(SensitiveAndUnsanitized).Name, SensitiveAndUnsanitized.OriginalValueRepresentation}
+                                                        });
+            _logger = new SomeRecordingLogger();
+
+            return new SettingsRegistrationService(_logger,
+                                                   typeProvider,
+                                                   SettingKeyConventions.BuiltInConventions.ToArray(),
+                                                   settingsReader,
+                                                   new EnvironmentVariableSettingsOverrider(), 
+                                                   new SettingValueConverter(),
+                                                   true,
+                                                   setting => { }
+                );
+        }
+
+        protected override void When()
+        {
+        }
+
+        private class SomeRecordingLogger : IConfigInjectorLogger
+        {
+            public List<string> LogEntries { get; }
+
+            public SomeRecordingLogger()
+            {
+                LogEntries = new List<string>();
+            }
+
+            public void Log(string template, params object[] args)
+            {
+                LogEntries.Add(string.Format(template, args));
+            }
+        }
+
+        private class SensitiveAndUnsanitized : ConfigurationSetting<string>
+        {
+            public const string OriginalValueRepresentation = "SomewhatSensitive";
+            public const string OverridenValueRepresentation = "OverridenAndSomewhatSensitive";
+
+            public override bool IsSensitive { get { return true; } }
+        }
+
+        private class SensitiveAndSanitized : ConfigurationSetting<string>
+        {
+            public const string OriginalValueRepresentation = "ReallySensitive";
+            public const string OverridenValueRepresentation = "OverridenAndReallySensitive";
+            public const string SanitizedValueRepresentation = "#####";
+
+            public override bool IsSensitive { get { return true; } }
+            public override string SanitizedValue { get { return SanitizedValueRepresentation; } }
+        }
+
+        [Test]
+        public void AnOverridenSensitiveSettingWithoutASanitizedValueOverrideWillNotMaskTheLogOutput()
+        {
+            Environment.SetEnvironmentVariable(EnvironmentVariableSettingsOverrider.DefaultPrefix + "SensitiveAndUnsanitized", SensitiveAndUnsanitized.OverridenValueRepresentation);
+            Subject.GetConfigSettingFor(typeof(SensitiveAndUnsanitized));
+
+            CollectionAssert.IsNotEmpty(_logger.LogEntries);
+
+            var logEntry = _logger.LogEntries.First();
+
+            Assert.IsTrue(logEntry.Contains(typeof(SensitiveAndUnsanitized).Name));
+
+            Assert.IsFalse(logEntry.Contains(SensitiveAndSanitized.OriginalValueRepresentation));
+            Assert.IsTrue(logEntry.Contains(SensitiveAndUnsanitized.OverridenValueRepresentation));
+        }
+
+        [Test]
+        public void AnOverridenSensitiveSettingWithASanitizedValueWillMaskTheLogOutput()
+        {
+            Environment.SetEnvironmentVariable(EnvironmentVariableSettingsOverrider.DefaultPrefix + "SensitiveAndSanitized", SensitiveAndSanitized.OverridenValueRepresentation);
+            Subject.GetConfigSettingFor(typeof (SensitiveAndSanitized));
+
+            CollectionAssert.IsNotEmpty(_logger.LogEntries);
+
+            var logEntry = _logger.LogEntries.First();
+
+            Assert.IsTrue(logEntry.Contains(typeof(SensitiveAndSanitized).Name));
+
+            Assert.IsFalse(logEntry.Contains(SensitiveAndSanitized.OriginalValueRepresentation));
+            Assert.IsFalse(logEntry.Contains(SensitiveAndSanitized.OverridenValueRepresentation));
+            Assert.IsTrue(logEntry.Contains(SensitiveAndSanitized.SanitizedValueRepresentation));
+        }
+    }
+}

--- a/src/ConfigInjector/ConfigurationSetting.cs
+++ b/src/ConfigInjector/ConfigurationSetting.cs
@@ -51,7 +51,7 @@ namespace ConfigInjector
 
         public override string ToString()
         {
-            return "" + Value;
+            return "" + SanitizedValue;
         }
     }
 }

--- a/src/ConfigInjector/IConfigurationSetting.cs
+++ b/src/ConfigInjector/IConfigurationSetting.cs
@@ -2,5 +2,6 @@
 {
     public interface IConfigurationSetting
     {
+        bool IsSensitive { get; }
     }
 }


### PR DESCRIPTION
Hey Andrew.
As discussed, have had a stab at making the log output that `SettingsRegistrationService` produces after parsing a setting and determining if overridden respect the `IsSensitive`/`SanitizedValue` properties. I needed to instantiate the settings object before logging in order to do this, and also needed to pull the `IsSensitive` property up into the `IConfigurationSetting` interface. Let me know your feelings on this. I have added new unit tests that confirm the expected presence/absence of a sanitized setting with/without a value override.
Cheers,
Craig.
