### PR TITLE
Move ConfigInjector to its own GitHub organisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,11 +288,7 @@ it's going to be written to a log file or other insecure storage.
 It's worth noting that *these properties do not change the behaviour of ConfigInjector*; they simply allow us to be a bit more
 judicious when we're dealing with these settings.
 
-## Builds and package feeds
-
-Public build information is available at [https://ci.appveyor.com/project/ConfigInjector/configinjector](https://ci.appveyor.com/project/ConfigInjector/configinjector).
-
-![Build Status](https://ci.appveyor.com/api/projects/status/l6sqj2tvur6e04c6/branch/master?svg=true)
+## Package feeds
 
 ### Stable versions
 
@@ -305,3 +301,11 @@ Stable versions of the packages are available via nuget.org.
 
 Be careful! The pre-release feeds may contain builds from feature branches and
 pull requests as well as from the master branch.
+
+## Contributing
+
+The official repository for ConfigInjector is [https://github.com/ConfigInjector/ConfigInjector](https://github.com/ConfigInjector/ConfigInjector).
+
+Public build information is available at [https://ci.appveyor.com/project/ConfigInjector/configinjector](https://ci.appveyor.com/project/ConfigInjector/configinjector).
+
+![Build Status](https://ci.appveyor.com/api/projects/status/l6sqj2tvur6e04c6/branch/master?svg=true)

--- a/README.md
+++ b/README.md
@@ -288,7 +288,11 @@ it's going to be written to a log file or other insecure storage.
 It's worth noting that *these properties do not change the behaviour of ConfigInjector*; they simply allow us to be a bit more
 judicious when we're dealing with these settings.
 
-## Package feeds
+## Builds and package feeds
+
+Public build information is available at [https://ci.appveyor.com/project/ConfigInjector/configinjector](https://ci.appveyor.com/project/ConfigInjector/configinjector).
+
+![Build Status](https://ci.appveyor.com/api/projects/status/l6sqj2tvur6e04c6/branch/master?svg=true)
 
 ### Stable versions
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ConfigInjector
 
+![Build Status](https://ci.appveyor.com/api/projects/status/l6sqj2tvur6e04c6/branch/master?svg=true)
+
 ## How application settings *should* look:
 
 Here's a class that needs some configuration settings:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,38 @@
+version: 2.3.{build}.0
+configuration: Release
+assembly_info:
+  patch: true
+  file: '**\AssemblyInfo.*'
+  assembly_version: '{version}'
+  assembly_file_version: '{version}'
+  assembly_informational_version: '{version}'
+dotnet_csproj:
+  patch: true
+  file: '**\*.csproj'
+  version: '{version}'
+  package_version: '{version}'
+  assembly_version: '{version}'
+  file_version: '{version}'
+  informational_version: '{version}'
+nuget:
+  disable_publish_on_pr: true
+before_build:
+- cmd: >-
+    cd src
+
+    nuget restore
+
+    cd ..
+build:
+  publish_nuget: true
+  publish_nuget_symbols: true
+  parallel: true
+  verbosity: minimal
+deploy:
+- provider: NuGet
+  server: https://www.myget.org/F/config-injector/api/v2/package
+  api_key:
+    secure: IvGko7aRx36m46T8v3gbLfpqicRNCjp/ihlt/pNKezJDra9mtGnIsmfJYt1fAqlZ
+  symbol_server: https://www.myget.org/F/config-injector/symbols/api/v2/package
+  on:
+    branch: master

--- a/src/Sample.UnitTests/Sample.UnitTests.csproj
+++ b/src/Sample.UnitTests/Sample.UnitTests.csproj
@@ -30,7 +30,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.3.7.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>

--- a/src/Sample.UnitTests/WhenConstructingDeepThought.cs
+++ b/src/Sample.UnitTests/WhenConstructingDeepThought.cs
@@ -1,10 +1,8 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Sample.Configuration;
 
 namespace Sample.UnitTests
 {
-    [TestClass]
     [TestFixture]
     public class WhenConstructingDeepThought
     {
@@ -13,26 +11,23 @@ namespace Sample.UnitTests
 
         private DeepThought _deepThought;
 
-        [TestInitialize]
         [SetUp]
         public void SetUp()
         {
-            _deepThought = new DeepThought(new QuestionConfigurationSetting { Value = _theQuestion },
-                                           new AnswerConfigurationSetting { Value = _theAnswer });
+            _deepThought = new DeepThought(new QuestionConfigurationSetting {Value = _theQuestion},
+                                           new AnswerConfigurationSetting {Value = _theAnswer});
         }
 
-        [TestMethod]
         [Test]
         public void TheQuestionShouldBeCorrect()
         {
-            NUnit.Framework.Assert.AreEqual(_theQuestion, _deepThought.Question);
+            Assert.AreEqual(_theQuestion, _deepThought.Question);
         }
 
-        [TestMethod]
         [Test]
         public void TheAnswerShouldBeCorrect()
         {
-            NUnit.Framework.Assert.AreEqual(_theAnswer, _deepThought.Answer);
+            Assert.AreEqual(_theAnswer, _deepThought.Answer);
         }
     }
 }


### PR DESCRIPTION
As people might have noticed, I'm not keeping up with my open source work and need help. I'm preparing to transfer ConfigInjector to a separate GitHub organisation so that I can give other people easier access to the repository.